### PR TITLE
fix S3 client builder region

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,4 +8,6 @@ dependencies {
 	testImplementation group: 'junit', name: 'junit', version: '4.13'
 	testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
 	testImplementation 'com.google.guava:guava:18.0'
+	testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+	testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 }

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/S3.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/S3.java
@@ -1,28 +1,37 @@
 package com.spredfast.kafka.connect.s3;
 
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.S3ClientOptions;
 
 import java.util.Map;
 import java.util.Objects;
+
+import static com.amazonaws.services.s3.AmazonS3Client.S3_SERVICE_NAME;
+import static com.amazonaws.util.AwsHostNameUtils.parseRegion;
+import static java.lang.Boolean.parseBoolean;
 
 public class S3 {
 
 	public static AmazonS3 s3client(Map<String, String> config) {
 		// Use default credentials provider that looks in Env + Java properties + profile + instance role
-		AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
+		AmazonS3ClientBuilder s3Client = AmazonS3ClientBuilder.standard();
 
 		// If worker config sets explicit endpoint override (e.g. for testing) use that
+		setS3Endpoint(config, s3Client);
+		if (parseBoolean(config.get("s3.path_style"))) {
+			s3Client.setPathStyleAccessEnabled(true);
+		}
+		return s3Client.build();
+	}
+
+	private static void setS3Endpoint(Map<String, String> config, AmazonS3ClientBuilder s3Client) {
 		String s3Endpoint = config.get("s3.endpoint");
 		if (s3Endpoint != null && !Objects.equals(s3Endpoint, "")) {
-			s3Client.setEndpoint(s3Endpoint);
+			s3Client.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+				s3Endpoint, parseRegion(s3Endpoint, S3_SERVICE_NAME)
+			));
 		}
-		Boolean s3PathStyle = Boolean.parseBoolean(config.get("s3.path_style"));
-		if (s3PathStyle) {
-			s3Client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build());
-		}
-		return s3Client;
 	}
 
 }

--- a/common/src/test/java/com/spredfast/kafka/connect/s3/S3ClientTest.java
+++ b/common/src/test/java/com/spredfast/kafka/connect/s3/S3ClientTest.java
@@ -1,0 +1,29 @@
+package com.spredfast.kafka.connect.s3;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+
+public class S3ClientTest {
+	@Rule
+	public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+	@Test
+	public void shouldConstructClient() {
+		// set the AWS region for test purposes
+		environmentVariables.set("AWS_REGION", "eu-west-2");
+		Map<String, String> config = new HashMap<>();
+		config.put("s3.endpoint", "https://s3-eu-west-2.amazonaws.com");
+		AmazonS3 client = S3.s3client(config);
+		assertThat(client, not(nullValue()));
+	}
+}


### PR DESCRIPTION
Towards eeveebank/platform-engineering/issues/1491

Experiencing the following error:

```
kafka-connect-64b649cccb-65b7w kafka-connect java.lang.UnsupportedOperationException: Client is immutable when created with the builder.
kafka-connect-64b649cccb-65b7w kafka-connect 	at com.spredfast.shade.amazonaws.AmazonWebServiceClient.checkMutability(AmazonWebServiceClient.java:1057)
kafka-connect-64b649cccb-65b7w kafka-connect 	at com.spredfast.shade.amazonaws.AmazonWebServiceClient.setEndpoint(AmazonWebServiceClient.java:316)
kafka-connect-64b649cccb-65b7w kafka-connect 	at com.spredfast.shade.amazonaws.services.s3.AmazonS3Client.setEndpoint(AmazonS3Client.java:730)
kafka-connect-64b649cccb-65b7w kafka-connect 	at com.spredfast.kafka.connect.s3.S3.s3client(S3.java:19)
kafka-connect-64b649cccb-65b7w kafka-connect 	at com.spredfast.kafka.connect.s3.sink.S3SinkTask.start(S3SinkTask.java:80)
kafka-connect-64b649cccb-65b7w kafka-connect 	at org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:304)
kafka-connect-64b649cccb-65b7w kafka-connect 	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:195)
kafka-connect-64b649cccb-65b7w kafka-connect 	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
kafka-connect-64b649cccb-65b7w kafka-connect 	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
kafka-connect-64b649cccb-65b7w kafka-connect 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
kafka-connect-64b649cccb-65b7w kafka-connect 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
kafka-connect-64b649cccb-65b7w kafka-connect 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
kafka-connect-64b649cccb-65b7w kafka-connect 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
kafka-connect-64b649cccb-65b7w kafka-connect 	at java.lang.Thread.run(Thread.java:748)
```