### PR TITLE
SSV-1151: Backup Kafka message headers.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,3 +33,9 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+
+
+[*.java]
+# Prevent star (*) imports
+ij_java_class_count_to_use_import_on_demand = 9999
+ij_java_names_count_to_use_import_on_demand = 9999

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	api project(':api')
 	api group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.860'
 	api group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.11.860'
+	implementation 'com.google.code.gson:gson:2.9.0'
 
 	testImplementation group: 'junit', name: 'junit', version: '4.13'
 	testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.9.5'

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/ByteLengthFormat.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/ByteLengthFormat.java
@@ -1,15 +1,14 @@
 package com.spredfast.kafka.connect.s3;
 
-import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
-
+import com.google.gson.Gson;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.common.header.Headers;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Encodes raw bytes, prefixed by a 4 byte, big-endian integer
@@ -19,6 +18,12 @@ public class ByteLengthFormat implements S3RecordFormat, Configurable {
 
 	private static final int LEN_SIZE = 4;
 	private static final byte[] NO_BYTES = {};
+
+	// TODO decide on value and size of header marker
+	private static final int HEADER_MARKER = -10;
+	private static final int HEADER_MARKER_SIZE = 1;
+
+	private static final Gson GSON = new Gson();
 
 	private Optional<Boolean> includesKeys;
 
@@ -44,15 +49,37 @@ public class ByteLengthFormat implements S3RecordFormat, Configurable {
 		// write optionally the key, and the value, each preceded by their length
 		byte[] key = includesKeys.flatMap(t -> Optional.ofNullable(r.key())).orElse(NO_BYTES);
 		byte[] value = Optional.ofNullable(r.value()).orElse(NO_BYTES);
-		byte[] result = new byte[LEN_SIZE + value.length + (includesKeys.map(t -> key.length + LEN_SIZE).orElse(0))];
+		Optional<byte[]> headers = serialiseHeaders(r.headers());
+
+		int keyBlockLength = includesKeys.map(t -> LEN_SIZE + key.length).orElse(0);
+		int valueBlockLength = LEN_SIZE + value.length;
+		int headerBlockLength = headers.map(t -> HEADER_MARKER_SIZE + LEN_SIZE + t.length).orElse(0);
+		byte[] result = new byte[keyBlockLength + valueBlockLength + headerBlockLength];
 		ByteBuffer wrapped = ByteBuffer.wrap(result);
+
 		includesKeys.ifPresent(t -> {
 			wrapped.putInt(key.length);
 			wrapped.put(key);
 		});
+
 		wrapped.putInt(value.length);
 		wrapped.put(value);
+
+		if (headers.isPresent()) {
+			wrapped.put((byte) HEADER_MARKER);
+			wrapped.putInt(headers.get().length);
+			wrapped.put(headers.get());
+		}
+
 		return result;
+	}
+
+	private Optional<byte[]> serialiseHeaders(Headers headers) {
+		return Optional.ofNullable(headers)
+			.map(Headers::toArray)
+			.filter(a -> a.length > 0)
+			.map(GSON::toJson)
+			.map(a -> a.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Override

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/ByteLengthFormat.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/ByteLengthFormat.java
@@ -18,6 +18,17 @@ import static com.spredfast.kafka.connect.s3.Constants.NO_BYTES;
 /**
  * Encodes raw bytes, prefixed by a 4 byte, big-endian integer
  * indicating the length of the byte sequence.
+ * <p>
+ * If the record contains headers then the value block is followed by:
+ * - a single byte of value 0xF6
+ * - a 4 byte, big-endian integer indicating the length of the headers' byte sequence
+ * - the byte array representation of the headers encoded os JSON
+ * <p>
+ * The value of the header marker (0xF6) is arbitrary.
+ * It just needs to be a value that would not normally be at the start of the next record's 4 byte integer -- i.e. a negative value.
+ * <p>
+ * A more concise headers encoding was considered, such as the variable length encoding used for the message key and value, but care would be needed to differentiate nulls and empty strings.
+ * JSON is easy and storage is cheap.
  */
 public class ByteLengthFormat implements S3RecordFormat, Configurable {
 

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
@@ -1,19 +1,32 @@
 package com.spredfast.kafka.connect.s3;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.errors.DataException;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.connect.errors.DataException;
-import com.spredfast.kafka.connect.s3.RecordReader;
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NO_TIMESTAMP;
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_CHECKSUM;
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE;
 
 /**
  * Helper for reading raw length encoded records from a chunk file. Not thread safe.
  */
 public class BytesRecordReader implements RecordReader {
-
+	private static final Gson GSON = new Gson();
 	private final ByteBuffer lenBuffer = ByteBuffer.allocate(4);
 
 	private final boolean includesKeys;
@@ -25,6 +38,20 @@ public class BytesRecordReader implements RecordReader {
 		this.includesKeys = includesKeys;
 	}
 
+	public class ReadContext {
+		String topic;
+		int partition;
+		long offset;
+		BufferedInputStream data;
+
+		public ReadContext(final String topic, final int partition, final long offset, final BufferedInputStream data) {
+			this.topic = topic;
+			this.partition = partition;
+			this.offset = offset;
+			this.data = data;
+		}
+	}
+
 	/**
 	 * Reads a record from the given uncompressed data stream.
 	 *
@@ -32,65 +59,115 @@ public class BytesRecordReader implements RecordReader {
 	 */
 	@Override
 	public ConsumerRecord<byte[], byte[]> read(String topic, int partition, long offset, BufferedInputStream data) throws IOException {
+		ReadContext context = new ReadContext(topic, partition, offset, data);
+		return read(context);
+	}
+
+	public ConsumerRecord<byte[], byte[]> read(final ReadContext context) throws IOException {
+		if (!context.data.markSupported()) {
+			throw new RuntimeException("Reader is not mark supported"); // TODO improve exception type and message
+		}
 		final byte[] key;
 		final int valSize;
 		if (includesKeys) {
 			// if at the end of the stream, return null
-			final Integer keySize = readLen(topic, partition, offset, data);
+			final Integer keySize = readLen(context);
 			if (keySize == null) {
 				return null;
 			}
-			key = readBytes(keySize, data, topic, partition, offset);
-			valSize = readValueLen(topic, partition, offset, data);
+			key = readBytes(keySize, context);
+			valSize = readValueLen(context);
 		} else {
 			key = null;
-			Integer vSize = readLen(topic, partition, offset, data);
+			Integer vSize = readLen(context);
 			if (vSize == null) {
 				return null;
 			}
 			valSize = vSize;
 		}
 
-		final byte[] value = readBytes(valSize, data, topic, partition, offset);
+		final byte[] value = readBytes(valSize, context);
 
-		return new ConsumerRecord<>(topic, partition, offset, key, value);
+		Headers headers = readHeaders(context);
+
+		return new ConsumerRecord<>(context.topic, context.partition, context.offset, NO_TIMESTAMP, TimestampType.NO_TIMESTAMP_TYPE,
+			(long) NULL_CHECKSUM, NULL_SIZE, NULL_SIZE, key, value, headers);
 	}
 
-	private int readValueLen(String topic, int partition, long offset, InputStream data) throws IOException {
-		final Integer len = readLen(topic, partition, offset, data);
+	private boolean isNextByteTheHeaderMarker(final ReadContext context) throws IOException {
+		if (hasNextByte(context.data)) {
+			final byte[] headerMarker = readBytes(1, context);
+			return headerMarker.length == 1 && headerMarker[0] == -10;
+		}
+		return false;
+	}
+
+	private Headers readHeaders(final ReadContext context) throws IOException {
+		// Mark our current position, so we can move back if there is no header
+		context.data.mark(1);
+
+		if (!isNextByteTheHeaderMarker(context)) {
+			// Reset stream to before the non-existent header
+			context.data.reset();
+			return new RecordHeaders();
+		}
+
+		int headerSize = readValueLen(context);
+		byte[] headerBlock = readBytes(headerSize, context);
+		return deserialiseHeaders(headerBlock);
+	}
+
+	private Headers deserialiseHeaders(final byte[] headerBlock) {
+		String jsonString = new String(headerBlock);
+		Type listType = new TypeToken<ArrayList<RecordHeader>>() {
+		}.getType();
+		List<Header> headers = GSON.fromJson(jsonString, listType);
+		return new RecordHeaders(headers);
+	}
+
+	private int readValueLen(ReadContext context) throws IOException {
+		final Integer len = readLen(context);
 		if (len == null) {
-			die(topic, partition, offset);
+			die(context);
 		}
 		return len;
 	}
 
-	private byte[] readBytes(int keySize, InputStream data, String topic, int partition, long offset) throws IOException {
+	private byte[] readBytes(int keySize, ReadContext context) throws IOException {
 		final byte[] bytes = new byte[keySize];
 		int read = 0;
 		while (read < keySize) {
-			final int readNow = data.read(bytes, read, keySize - read);
+			final int readNow = context.data.read(bytes, read, keySize - read);
 			if (readNow == -1) {
-				die(topic, partition, offset);
+				die(context);
 			}
 			read += readNow;
 		}
 		return bytes;
 	}
 
-	private Integer readLen(String topic, int partition, long offset, InputStream data) throws IOException {
+	private Integer readLen(ReadContext context) throws IOException {
 		lenBuffer.rewind();
-		int read = data.read(lenBuffer.array(), 0, 4);
+		int read = context.data.read(lenBuffer.array(), 0, 4);
 		if (read == -1) {
 			return null;
 		} else if (read != 4) {
-			die(topic, partition, offset);
+			die(context);
 		}
 		return lenBuffer.getInt();
 	}
 
+	private boolean hasNextByte(InputStream data) throws IOException {
+		data.mark(1);
+		ByteBuffer peekBuffer = ByteBuffer.allocate(1);
+		int read = data.read(peekBuffer.array(), 0, 1);
+		data.reset();
+		return read != -1;
+	}
 
-	protected ConsumerRecord<byte[], byte[]> die(String topic, int partition, long offset) {
-		throw new DataException(String.format("Corrupt record at %s-%d:%d", topic, partition, offset));
+
+	protected ConsumerRecord<byte[], byte[]> die(ReadContext context) {
+		throw new DataException(String.format("Corrupt record at %s-%d:%d", context.topic, context.partition, context.offset));
 	}
 
 }

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
@@ -42,7 +42,7 @@ public class BytesRecordReader implements RecordReader {
 		this.includesKeys = includesKeys;
 	}
 
-	public class ReadContext {
+	public static class ReadContext {
 		String topic;
 		int partition;
 		long offset;
@@ -68,9 +68,6 @@ public class BytesRecordReader implements RecordReader {
 	}
 
 	public ConsumerRecord<byte[], byte[]> read(final ReadContext context) throws IOException {
-		if (!context.data.markSupported()) {
-			throw new RuntimeException("Reader is not mark supported"); // TODO improve exception type and message
-		}
 		final byte[] key;
 		final int valSize;
 		if (includesKeys) {

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/BytesRecordReader.java
@@ -18,6 +18,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.spredfast.kafka.connect.s3.Constants.HEADER_MARKER;
+import static com.spredfast.kafka.connect.s3.Constants.HEADER_MARKER_SIZE;
+import static com.spredfast.kafka.connect.s3.Constants.LENGTH_FIELD_SIZE;
 import static org.apache.kafka.clients.consumer.ConsumerRecord.NO_TIMESTAMP;
 import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_CHECKSUM;
 import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE;
@@ -27,7 +30,7 @@ import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE;
  */
 public class BytesRecordReader implements RecordReader {
 	private static final Gson GSON = new Gson();
-	private final ByteBuffer lenBuffer = ByteBuffer.allocate(4);
+	private final ByteBuffer lenBuffer = ByteBuffer.allocate(LENGTH_FIELD_SIZE);
 
 	private final boolean includesKeys;
 

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/Constants.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/Constants.java
@@ -2,4 +2,15 @@ package com.spredfast.kafka.connect.s3;
 
 public class Constants {
 	public static final String VERSION = "0.0.1";
+
+	public static final int LENGTH_FIELD_SIZE = 4;
+
+	public static final byte[] NO_BYTES = {};
+
+	public static final byte HEADER_MARKER = (byte) 0xF6;
+
+	public static final int HEADER_MARKER_SIZE = 1;
+
+	private Constants() {
+	}
 }

--- a/common/src/test/java/com/spredfast/kafka/connect/s3/ByteLengthFormatTest.java
+++ b/common/src/test/java/com/spredfast/kafka/connect/s3/ByteLengthFormatTest.java
@@ -1,26 +1,111 @@
 package com.spredfast.kafka.connect.s3;
 
-import java.io.IOException;
-
-import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.spredfast.kafka.connect.s3.FormatTests.assertBytesAreEqual;
 
 public class ByteLengthFormatTest {
 
 	@Test
 	public void defaults() throws IOException {
-		FormatTests.roundTrip_singlePartition_fromZero_withNullKeys(givenFormatWithConfig(ImmutableMap.of()), givenValues());
+		FormatTests.roundTrip_singlePartition_fromZero_withNullKeys(givenFormatWithConfig(ImmutableMap.of()),
+			ImmutableList.of(
+				FormatTests.Record.valueOnly("abcd"),
+				FormatTests.Record.valueOnly("567\tav"),
+				FormatTests.Record.valueOnly("238473210984712309\n84710923847231098472390847324098543298652938475\n49837")
+			)
+		);
 	}
 
 	@Test
 	public void withKeys() throws IOException {
-		FormatTests.roundTrip_singlePartition_fromZero_withNullKeys(givenFormatWithConfig(ImmutableMap.of("include.keys", "true")), givenValues());
+		FormatTests.roundTrip_singlePartition_fromZero_withKeys(givenFormatWithConfig(ImmutableMap.of("include.keys", "true")),
+			ImmutableList.of(
+				FormatTests.Record.keysAndValueOnly("k1", "abcd"),
+				FormatTests.Record.keysAndValueOnly("k2", "567\tav"),
+				FormatTests.Record.keysAndValueOnly("k3", "238473210984712309\n84710923847231098472390847324098543298652938475\n49837")
+			),
+			0);
+	}
+
+	@Test
+	public void withKeysAndHeaders() throws IOException {
+		FormatTests.roundTrip_singlePartition_fromZero_withKeysAndHeaders(givenFormatWithConfig(ImmutableMap.of("include.keys", "true")),
+			ImmutableList.of(
+				new FormatTests.Record("k1", "abcd", new RecordHeaders()),
+				new FormatTests.Record("k2", "567\tav", new RecordHeaders(new RecordHeader[]{
+					new RecordHeader("h1", "".getBytes(StandardCharsets.UTF_8)),
+					new RecordHeader("h2", (byte[]) null),
+					new RecordHeader("h3", "foo".getBytes(StandardCharsets.UTF_8)),
+					new RecordHeader("h4", UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8)),
+				})),
+				new FormatTests.Record("k3", "238473210984712309\n84710923847231098472390847324098543298652938475\n49837", new RecordHeaders(new RecordHeader[]{
+					new RecordHeader("h1", "foo".getBytes(StandardCharsets.UTF_8)),
+				}))
+			),
+			0);
 	}
 
 
-	private ImmutableList<String> givenValues() {
-		return ImmutableList.of("abcd", "567\tav", "238473210984712309\n84710923847231098472390847324098543298652938475\n49837");
+	@Test
+	public void outputWithKeys() {
+		ByteLengthFormat format = givenFormatWithConfig(ImmutableMap.of("include.keys", "true"));
+
+		byte[] key = "abc".getBytes(StandardCharsets.UTF_8);
+		byte[] value = "defghi".getBytes(StandardCharsets.UTF_8);
+
+		int numberOfByteForLengthMarker = 4;
+
+		byte[] expected = new byte[numberOfByteForLengthMarker + key.length + numberOfByteForLengthMarker + value.length];
+		ByteBuffer buffer = ByteBuffer.wrap(expected);
+
+		buffer.putInt(key.length);
+		buffer.put(key);
+		buffer.putInt(value.length);
+		buffer.put(value);
+
+		assertBytesAreEqual(expected, format.newWriter().writeBatch(Stream.of(new ProducerRecord<>("topic", key, value))).findFirst().get());
+	}
+
+	@Test
+	public void outputWithKeysAndHeaders() {
+		ByteLengthFormat format = givenFormatWithConfig(ImmutableMap.of("include.keys", "true"));
+
+		byte[] key = "abc".getBytes(StandardCharsets.UTF_8);
+		byte[] value = "defghi".getBytes(StandardCharsets.UTF_8);
+		Headers headers = new RecordHeaders(new RecordHeader[]{new RecordHeader("h1", "foo".getBytes(StandardCharsets.UTF_8))});
+		byte[] serialisedHeaders = "[{\"key\":\"h1\",\"value\":[102,111,111]}]".getBytes(StandardCharsets.UTF_8);
+
+		int numberOfByteForLengthMarker = 4;
+		int numberOfByteForHeaderMarker = 1;
+
+		byte[] expected = new byte[numberOfByteForLengthMarker + key.length +
+			numberOfByteForLengthMarker + value.length +
+			numberOfByteForLengthMarker + numberOfByteForHeaderMarker + serialisedHeaders.length
+			];
+		ByteBuffer buffer = ByteBuffer.wrap(expected);
+
+		buffer.putInt(key.length);
+		buffer.put(key);
+		buffer.putInt(value.length);
+		buffer.put(value);
+		buffer.put((byte) -10);
+		buffer.putInt(serialisedHeaders.length);
+		buffer.put(serialisedHeaders);
+
+		assertBytesAreEqual(expected, format.newWriter().writeBatch(Stream.of(new ProducerRecord<>("topic", null, key, value, headers))).findFirst().get());
 	}
 
 	private ByteLengthFormat givenFormatWithConfig(ImmutableMap<String, Object> configs) {

--- a/common/src/test/java/com/spredfast/kafka/connect/s3/TrailingDelimiterFormatTest.java
+++ b/common/src/test/java/com/spredfast/kafka/connect/s3/TrailingDelimiterFormatTest.java
@@ -4,54 +4,99 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Base64;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static com.spredfast.kafka.connect.s3.FormatTests.assertBytesAreEqual;
 
 public class TrailingDelimiterFormatTest {
 
 	@Test
 	public void defaults() throws IOException {
-		FormatTests.roundTrip_singlePartition_fromZero_withNullKeys(givenFormatWithConfig(ImmutableMap.of()), givenValues());
+		FormatTests.roundTrip_singlePartition_fromZero_withNullKeys(givenFormatWithConfig(ImmutableMap.of()), ImmutableList.of(
+			FormatTests.Record.valueOnly("abcd"),
+			FormatTests.Record.valueOnly("567\tav"),
+			FormatTests.Record.valueOnly("2384732109847123098471092384723109847239084732409854329865293847549837")
+		));
 	}
 
 	@Test
 	public void withKeys() throws IOException {
 		FormatTests.roundTrip_singlePartition_fromZero_withKeys(givenFormatWithConfig(ImmutableMap.of(
 			"key.delimiter", "\t"
-		)), ImmutableMap.of(
-			"123", "456",
-			"abc\ndef", "ghi\tjkl"
+		)), ImmutableList.of(
+			FormatTests.Record.keysAndValueOnly("123", "456"),
+			FormatTests.Record.keysAndValueOnly("abc\ndef", "ghi\tjkl")
 		), 0);
 	}
 
 	@Test
-	public void output() throws IOException {
+	public void withKeysAndHeaders() throws IOException {
+		FormatTests.roundTrip_singlePartition_fromZero_withKeysAndHeaders(givenFormatWithConfig(ImmutableMap.of("key.delimiter", "\t")),
+			ImmutableList.of(
+				new FormatTests.Record("k1", "abcd", new RecordHeaders()),
+				new FormatTests.Record("k2", "567av", new RecordHeaders(new RecordHeader[]{
+					new RecordHeader("h1", "".getBytes(StandardCharsets.UTF_8)),
+					new RecordHeader("h2", (byte[]) null),
+					new RecordHeader("h3", "foo".getBytes(StandardCharsets.UTF_8)),
+					new RecordHeader("h4", UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8)),
+				})),
+				new FormatTests.Record("k3", "23847321098471230984710923847231098472390847324098543298652938475", new RecordHeaders(new RecordHeader[]{
+					new RecordHeader("h1", "foo".getBytes(StandardCharsets.UTF_8)),
+				}))
+			),
+			0);
+	}
+
+	@Test
+	public void outputWithKeys() {
 		// using UTF_16BE because UTF_16 adds a byte order mark to every invocation of getBytes, which is annoying
 		TrailingDelimiterFormat format = givenFormatWithConfig(ImmutableMap.of(
 			"key.delimiter", "\t",
 			"key.encoding", "UTF-16BE",
-			"value.encoding", "UTF-16BE"
+			"value.encoding", "UTF-16BE",
+			"header.encoding", "UTF-16BE"
 		));
+		byte[] keyAndValue = "abc\tdef\n".getBytes(Charsets.UTF_16BE);
+		byte[] headerDelimiter = new byte[]{0, 11};
+		byte[] expected = new byte[keyAndValue.length + headerDelimiter.length];
+		System.arraycopy(keyAndValue, 0, expected, 0, keyAndValue.length);
+		System.arraycopy(headerDelimiter, 0, expected, keyAndValue.length, headerDelimiter.length);
 
-		assertBytesAreEqual("abc\tdef\n".getBytes(Charsets.UTF_16BE), format.newWriter().writeBatch(Stream.of(
+		assertBytesAreEqual(expected, format.newWriter().writeBatch(Stream.of(
 			new ProducerRecord<>("topic", "abc".getBytes(Charsets.UTF_16BE), "def".getBytes(Charsets.UTF_16BE))
 		)).findFirst().get());
 	}
 
-	private void assertBytesAreEqual(byte[] expected, byte[] actual) {
-		if (!Arrays.equals(expected, actual)) {
-			assertEquals(Base64.getEncoder().encodeToString(expected), Base64.getEncoder().encodeToString(actual));
-		}
-	}
+	@Test
+	public void outputWithKeysAndHeaders() {
+		// using UTF_16BE because UTF_16 adds a byte order mark to every invocation of getBytes, which is annoying
+		TrailingDelimiterFormat format = givenFormatWithConfig(ImmutableMap.of(
+			"key.delimiter", "\t",
+			"key.encoding", "UTF-16BE",
+			"value.encoding", "UTF-16BE",
+			"header.encoding", "UTF-16BE"
+		));
+		byte[] keyAndValue = "abc\tdef\n".getBytes(Charsets.UTF_16BE);
+		byte[] headers = "[{\"key\":\"h1\",\"value\":[0,102,0,111,0,111]}]".getBytes(Charsets.UTF_8);
+		byte[] headerDelimiter = new byte[]{0, 11};
+		byte[] expected = new byte[keyAndValue.length + headers.length + headerDelimiter.length];
+		System.arraycopy(keyAndValue, 0, expected, 0, keyAndValue.length);
+		System.arraycopy(headers, 0, expected, keyAndValue.length, headers.length);
+		System.arraycopy(headerDelimiter, 0, expected, keyAndValue.length + headers.length, headerDelimiter.length);
 
-	private ImmutableList<String> givenValues() {
-		return ImmutableList.of("abcd", "567\tav", "2384732109847123098471092384723109847239084732409854329865293847549837");
+		assertBytesAreEqual(expected, format.newWriter().writeBatch(Stream.of(
+			new ProducerRecord<>(
+				"topic", null, "abc".getBytes(Charsets.UTF_16BE), "def".getBytes(Charsets.UTF_16BE),
+				new RecordHeaders(new RecordHeader[]{new RecordHeader("h1", "foo".getBytes(StandardCharsets.UTF_16BE))})
+			)
+		)).findFirst().get());
 	}
 
 	private TrailingDelimiterFormat givenFormatWithConfig(ImmutableMap<String, Object> configs) {

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -4,8 +4,13 @@ dependencies {
 	api project(':common')
 
 	testImplementation project(':sink')
-	testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3'
-	testImplementation group: 'org.testcontainers', name: 'localstack', version: '1.14.3'
-	testImplementation group: 'junit', name: 'junit', version: '4.12'
+	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
+	testImplementation "org.testcontainers:testcontainers:1.17.3"
+	testImplementation "org.testcontainers:localstack:1.17.3"
+	testImplementation "org.testcontainers:junit-jupiter:1.17.3"
 	testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
+}
+
+test {
+	useJUnitPlatform()
 }

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
@@ -1,6 +1,26 @@
 package com.spredfast.kafka.connect.s3.source;
 
-import static java.util.stream.Collectors.toList;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.spredfast.kafka.connect.s3.LazyString;
+import com.spredfast.kafka.connect.s3.S3RecordsReader;
+import com.spredfast.kafka.connect.s3.json.ChunkDescriptor;
+import com.spredfast.kafka.connect.s3.json.ChunksIndex;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,22 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.spredfast.kafka.connect.s3.LazyString;
-import com.spredfast.kafka.connect.s3.S3RecordsReader;
-import com.spredfast.kafka.connect.s3.json.ChunkDescriptor;
-import com.spredfast.kafka.connect.s3.json.ChunksIndex;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Helpers for reading records out of S3. Not thread safe.
@@ -159,7 +164,7 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 					List<S3ObjectSummary> chunks = new ArrayList<>(objectListing.getObjectSummaries().size() / 2);
 					for (S3ObjectSummary chunk : objectListing.getObjectSummaries()) {
 						if (DATA_SUFFIX.matcher(chunk.getKey()).find() && parseKeyUnchecked(chunk.getKey(),
-								(t, p, o) -> config.partitionFilter.matches(t, p))) {
+							(t, p, o) -> config.partitionFilter.matches(t, p))) {
 							S3Offset offset = offset(chunk);
 							if (offset != null) {
 								// if our offset for this partition is beyond this chunk, ignore it
@@ -191,7 +196,7 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 						S3RecordsReader reader = makeReader.get();
 						InputStream content = getContent(s3Client.getObject(config.bucket, currentKey));
 						iterator = parseKey(currentKey, (topic, partition, startOffset) -> {
-							reader.init(topic,partition, content, startOffset);
+							reader.init(topic, partition, content, startOffset);
 							return reader.readAll(topic, partition, content, startOffset);
 						});
 					}
@@ -281,9 +286,26 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 					record.topic(),
 					record.partition(),
 					record.key(),
-					record.value()
+					record.value(),
+					toConnectHeaders(record.headers())
 				);
 			}
+
+			private Headers toConnectHeaders(final org.apache.kafka.common.header.Headers commonHeaders) {
+				if (commonHeaders == null) {
+					return null;
+				}
+
+				ConnectHeaders connectHeaders = new ConnectHeaders();
+				// TODO tidy this up
+				for (Header h : commonHeaders) {
+					String value = h.value() == null ? null : new String(h.value());
+					Schema schema = value == null ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA;
+					connectHeaders.add(h.key(), new SchemaAndValue(schema, value));
+				}
+				return connectHeaders;
+			}
+
 
 			@Override
 			public void remove() {

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
@@ -297,11 +297,10 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 				}
 
 				ConnectHeaders connectHeaders = new ConnectHeaders();
-				// TODO tidy this up
-				for (Header h : commonHeaders) {
-					String value = h.value() == null ? null : new String(h.value());
+				for (Header header : commonHeaders) {
+					String value = header.value() == null ? null : new String(header.value());
 					Schema schema = value == null ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA;
-					connectHeaders.add(h.key(), new SchemaAndValue(schema, value));
+					connectHeaders.add(header.key(), new SchemaAndValue(schema, value));
 				}
 				return connectHeaders;
 			}

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceRecord.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceRecord.java
@@ -1,5 +1,7 @@
 package com.spredfast.kafka.connect.s3.source;
 
+import org.apache.kafka.connect.header.Headers;
+
 public class S3SourceRecord {
 	private final S3Partition file;
 	private final S3Offset offset;
@@ -7,15 +9,17 @@ public class S3SourceRecord {
 	private final int partition;
 	private final byte[] key;
 	private final byte[] value;
+	private final Headers headers;
 
 
-	public S3SourceRecord(S3Partition file, S3Offset offset, String topic, int partition, byte[] key, byte[] value) {
+	public S3SourceRecord(S3Partition file, S3Offset offset, String topic, int partition, byte[] key, byte[] value, final Headers headers) {
 		this.file = file;
 		this.offset = offset;
 		this.topic = topic;
 		this.partition = partition;
 		this.key = key;
 		this.value = value;
+		this.headers = headers;
 	}
 
 	public S3Partition file() {
@@ -40,5 +44,9 @@ public class S3SourceRecord {
 
 	public byte[] value() {
 		return value;
+	}
+
+	public Headers headers() {
+		return headers;
 	}
 }

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
@@ -9,8 +9,8 @@ import org.testcontainers.utility.DockerImageName;
 public class FakeS3 {
 
 	@Container
-	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("lphoward/fake-s3"))
-		.withExposedPorts(4569);
+	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("adobe/s3mock"))
+		.withExposedPorts(9090);
 
 	public void start() {
 		s3.start();

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
@@ -1,0 +1,26 @@
+package com.spredfast.kafka.connect.s3;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class FakeS3 {
+
+	@Container
+	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("lphoward/fake-s3"))
+		.withExposedPorts(4569);
+
+	public void start() {
+		s3.start();
+	}
+
+	public void close() {
+		s3.close();
+	}
+
+	public String getEndpoint() {
+		return String.format("http://%s:%s", s3.getHost(), s3.getFirstMappedPort());
+	}
+}

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -11,6 +11,9 @@ import com.spredfast.kafka.connect.s3.source.S3Partition;
 import com.spredfast.kafka.connect.s3.source.S3SourceConfig;
 import com.spredfast.kafka.connect.s3.source.S3SourceRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.Converter;
@@ -22,6 +25,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,7 +34,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,6 +50,9 @@ class S3FilesReaderTest {
 	private final FakeS3 s3 = new FakeS3();
 	private String bucketName = "bucket";
 	private static final Random RANDOM = new Random();
+
+	private static final BiFunction<String, String, Headers> headersFunction = (k, v) -> new RecordHeaders(new RecordHeader[]{new RecordHeader(k, v.getBytes(StandardCharsets.UTF_8))});
+
 
 	@BeforeEach
 	void setUp() {
@@ -58,11 +69,11 @@ class S3FilesReaderTest {
 	void testReadingBytesFromS3() throws IOException {
 		final AmazonS3 client = s3Client();
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(client, dir);
+		givenSomeDataWithKeys(client, dir);
 
 		List<String> results = whenTheRecordsAreRead(client, true, 3);
 
-		thenTheyAreFilteredAndInOrder(results);
+		thenTheyAreInOrder(results);
 	}
 
 	@Test
@@ -75,24 +86,24 @@ class S3FilesReaderTest {
 
 		List<String> results = whenTheRecordsAreRead(client, true, 10);
 
-		thenTheyAreFilteredAndInOrder(results);
+		thenTheyAreInOrder(results);
 	}
 
 	@Test
 	void testReadingBytesFromS3_withOffsets() throws IOException {
 		final AmazonS3 client = s3Client();
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(client, dir);
+		givenSomeDataWithKeys(client, dir);
 
 		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client,
 			"prefix/2015-12-31/topic-00003-000000000001.gz", 5L, "00003"));
 
 		assertEquals(Arrays.asList(
-			"willbe=skipped5",
-			"willbe=skipped6",
-			"willbe=skipped7",
-			"willbe=skipped8",
-			"willbe=skipped9"
+			"willbe=skipped5[skipped header key5:skipped header value5]",
+			"willbe=skipped6[skipped header key6:skipped header value6]",
+			"willbe=skipped7[skipped header key7:skipped header value7]",
+			"willbe=skipped8[skipped header key8:skipped header value8]",
+			"willbe=skipped9[skipped header key9:skipped header value9]"
 		), results);
 	}
 
@@ -101,23 +112,17 @@ class S3FilesReaderTest {
 	void testReadingBytesFromS3_withOffsetsAtEndOfFile() throws IOException {
 		final AmazonS3 client = s3Client();
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(client, dir);
+		givenSomeDataWithKeys(client, dir);
 
 		// this file will be skipped
 		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client,
 			"prefix/2015-12-30/topic-00003-000000000000.gz", 1L, "00003"));
 
-		assertEquals(Arrays.asList(
-			"willbe=skipped1",
-			"willbe=skipped2",
-			"willbe=skipped3",
-			"willbe=skipped4",
-			"willbe=skipped5",
-			"willbe=skipped6",
-			"willbe=skipped7",
-			"willbe=skipped8",
-			"willbe=skipped9"
-		), results);
+		assertEquals(
+			IntStream.range(1, 10)
+				.mapToObj(i -> String.format("willbe=skipped%d[skipped header key%d:skipped header value%d]", i, i, i))
+				.collect(toList()),
+			results);
 	}
 
 	S3FilesReader givenAReaderWithOffsets(AmazonS3 client, String marker, long nextOffset, final String partition) {
@@ -156,11 +161,11 @@ class S3FilesReaderTest {
 	void testReadingBytesFromS3_withoutKeys() throws IOException {
 		final AmazonS3 client = s3Client();
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(client, dir, false);
+		givenSomeDataWithoutKeys(client, dir);
 
 		List<String> results = whenTheRecordsAreRead(client, false);
 
-		theTheyAreInOrder(results);
+		theTheyAreInOrderWithoutKeys(results);
 	}
 
 	Converter givenACustomConverter() {
@@ -171,20 +176,20 @@ class S3FilesReaderTest {
 		return Configure.buildConverter(config, "converter", false, null);
 	}
 
-	void theTheyAreInOrder(List<String> results) {
+	void theTheyAreInOrderWithoutKeys(List<String> results) {
 		List<String> expected = Arrays.asList(
-			"value0-0",
-			"value1-0",
-			"value1-1"
+			"value0-0[header key 0-0:header value 0-0]",
+			"value1-0[header key 1-0:header value 1-0]",
+			"value1-1[header key 1-1:header value 1-1]"
 		);
 		assertEquals(expected, results);
 	}
 
-	private void thenTheyAreFilteredAndInOrder(List<String> results) {
+	private void thenTheyAreInOrder(List<String> results) {
 		List<String> expected = Arrays.asList(
-			"key0-0=value0-0",
-			"key1-0=value1-0",
-			"key1-1=value1-1"
+			"key0-0=value0-0[header key 0-0:header value 0-0]",
+			"key1-0=value1-0[header key 1-0:header value 1-0]",
+			"key1-1=value1-1[header key 1-1:header value 1-1]"
 		);
 		assertEquals(expected, results);
 	}
@@ -201,7 +206,13 @@ class S3FilesReaderTest {
 	private List<String> whenTheRecordsAreRead(S3FilesReader reader) {
 		List<String> results = new ArrayList<>();
 		for (S3SourceRecord record : reader) {
-			results.add((record.key() == null ? "" : new String(record.key()) + "=") + new String(record.value()));
+			String key = (record.key() == null ? "" : new String(record.key()) + "=");
+			String value = new String(record.value());
+			String headers = StreamSupport.stream(record.headers().spliterator(), false)
+				.map(h -> h.key() + ":" + (String) h.value())
+				.collect(Collectors.joining(","));
+
+			results.add(key + value + "[" + headers + "]");
 		}
 		return results;
 	}
@@ -215,15 +226,19 @@ class S3FilesReaderTest {
 		try (BlockGZIPFileWriter p0 = new BlockGZIPFileWriter("topic-00000", dir.toString() + "/prefix/2016-01-01", 0, 512);
 			 BlockGZIPFileWriter p1 = new BlockGZIPFileWriter("topic-00001", dir.toString() + "/prefix/2016-01-01", 0, 512);
 		) {
-			write(p0, "key0-0".getBytes(), "value0-0".getBytes(), includeKeys);
-			write(p1, "key1-0".getBytes(), "value1-0".getBytes(), includeKeys);
-			write(p1, "key1-1".getBytes(), "value1-1".getBytes(), includeKeys);
+			write(p0, "key0-0".getBytes(), "value0-0".getBytes(), headersFunction.apply("header key 0-0", "header value 0-0"), includeKeys);
+			write(p1, "key1-0".getBytes(), "value1-0".getBytes(), headersFunction.apply("header key 1-0", "header value 1-0"), includeKeys);
+			write(p1, "key1-1".getBytes(), "value1-1".getBytes(), headersFunction.apply("header key 1-1", "header value 1-1"), includeKeys);
 		}
 		uploadToS3(client, dir);
 	}
 
-	private void givenSomeData(AmazonS3 client, Path dir) throws IOException {
+	private void givenSomeDataWithKeys(AmazonS3 client, Path dir) throws IOException {
 		givenSomeData(client, dir, true);
+	}
+
+	private void givenSomeDataWithoutKeys(AmazonS3 client, Path dir) throws IOException {
+		givenSomeData(client, dir, false);
 	}
 
 	private void givenSomeData(AmazonS3 client, Path dir, boolean includeKeys) throws IOException {
@@ -236,16 +251,16 @@ class S3FilesReaderTest {
 			 BlockGZIPFileWriter writer2 = new BlockGZIPFileWriter("topic-00001", dir.toString() + "/prefix/2016-01-02", 0, 512);
 			 BlockGZIPFileWriter preWriter1 = new BlockGZIPFileWriter("topic-00003", dir.toString() + "/prefix/2015-12-30", 0, 512);
 		) {
-			write(preWriter1, "willbe".getBytes(), "skipped0".getBytes(), includeKeys);
+			write(preWriter1, "willbe".getBytes(), "skipped0".getBytes(), headersFunction.apply("skipped header key", "skipped header value"), includeKeys);
 
 			for (int i = 1; i < 10; i++) {
-				write(writer0, "willbe".getBytes(), ("skipped" + i).getBytes(), includeKeys);
+				write(writer0, "willbe".getBytes(), ("skipped" + i).getBytes(), headersFunction.apply("skipped header key" + i, "skipped header value" + i), includeKeys);
 			}
 
-			write(writer1, "key0-0".getBytes(), "value0-0".getBytes(), includeKeys);
+			write(writer1, "key0-0".getBytes(), "value0-0".getBytes(), headersFunction.apply("header key 0-0", "header value 0-0"), includeKeys);
 
-			write(writer2, "key1-0".getBytes(), "value1-0".getBytes(), includeKeys);
-			write(writer2, "key1-1".getBytes(), "value1-1".getBytes(), includeKeys);
+			write(writer2, "key1-0".getBytes(), "value1-0".getBytes(), headersFunction.apply("header key 1-0", "header value 1-0"), includeKeys);
+			write(writer2, "key1-1".getBytes(), "value1-1".getBytes(), headersFunction.apply("header key 1-1", "header value 1-1"), includeKeys);
 		}
 
 		uploadToS3(client, dir);
@@ -265,8 +280,10 @@ class S3FilesReaderTest {
 		});
 	}
 
-	private void write(BlockGZIPFileWriter writer, byte[] key, byte[] value, boolean includeKeys) throws IOException {
-		writer.write(new ByteLengthFormat(includeKeys).newWriter().writeBatch(Stream.of(new ProducerRecord<>("", key, value))).collect(toList()), 1);
+	private void write(BlockGZIPFileWriter writer, byte[] key, byte[] value, Headers headers, boolean includeKeys) throws IOException {
+		writer.write(new ByteLengthFormat(includeKeys).newWriter().writeBatch(Stream.of(
+			new ProducerRecord<>("", 0, key, value, headers)
+		)).collect(toList()), 1);
 	}
 
 	private AmazonS3 s3Client() {

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -16,7 +16,6 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.Converter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -79,7 +78,6 @@ class S3FilesReaderTest {
 		thenTheyAreFilteredAndInOrder(results);
 	}
 
-	@Disabled("Not reading all the records. The internal workings are too disgusting to understand why.")
 	@Test
 	void testReadingBytesFromS3_withOffsets() throws IOException {
 		final AmazonS3 client = s3Client();
@@ -99,7 +97,6 @@ class S3FilesReaderTest {
 	}
 
 
-	@Disabled("Not reading all the records. The internal workings are too disgusting to understand why.")
 	@Test
 	void testReadingBytesFromS3_withOffsetsAtEndOfFile() throws IOException {
 		final AmazonS3 client = s3Client();
@@ -155,7 +152,6 @@ class S3FilesReaderTest {
 		}
 	}
 
-	@Disabled("Not reading all the records. The internal workings are too disgusting to understand why.")
 	@Test
 	void testReadingBytesFromS3_withoutKeys() throws IOException {
 		final AmazonS3 client = s3Client();

--- a/system_test/build.gradle
+++ b/system_test/build.gradle
@@ -4,14 +4,23 @@ dependencies {
 	api project(':sink')
 	api project(':source')
 
-	testImplementation group: 'junit', name: 'junit', version: '4.12'
+	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
+	testImplementation "org.testcontainers:testcontainers:1.17.3"
+	testImplementation "org.testcontainers:junit-jupiter:1.17.3"
 	testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
+	testImplementation "org.assertj:assertj-guava:3.5.0"
 
-	testImplementation group: 'org.apache.kafka', name: 'connect-runtime', version: '0.10.1.0'
-	testImplementation group: 'org.apache.kafka', name: 'connect-json', version: '0.10.1.0'
-	testImplementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.10.1.0'
+	testImplementation group: 'org.apache.kafka', name: 'connect-runtime', version: '3.2.0'
+	testImplementation group: 'org.apache.kafka', name: 'connect-json', version: '3.2.0'
+	testImplementation group: 'org.apache.kafka', name: 'kafka_2.12', version: '3.2.0'
+	testImplementation group: 'org.apache.kafka', name: 'kafka-metadata', version: '3.2.0'
 
 	testImplementation group: 'com.netflix.curator', name: 'curator-test', version: '1.2.6'
 
-	testImplementation(group: 'com.spotify', name: 'docker-client', version: '6.0.0')
+	testImplementation(group: 'com.spotify', name: 'docker-client', version: '8.16.0')
 }
+
+test {
+	useJUnitPlatform()
+}
+

--- a/system_test/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
+++ b/system_test/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
@@ -1,77 +1,29 @@
 package com.spredfast.kafka.connect.s3;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.netflix.curator.test.InstanceSpec;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.exceptions.DockerException;
-import com.spotify.docker.client.messages.ContainerConfig;
-import com.spotify.docker.client.messages.ContainerCreation;
-import com.spotify.docker.client.messages.HostConfig;
-import com.spotify.docker.client.messages.PortBinding;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Created by noah on 10/20/16.
  */
+@Testcontainers
 public class FakeS3 {
-	private static final String IMAGE = "lphoward/fake-s3";
-	private static final String CONTAINER_PORT = "4569";
-	private final int hostPort;
-	private final ContainerCreation container;
 
+	@Container
+	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("lphoward/fake-s3"))
+		.withExposedPorts(4569);
 
-	private FakeS3(int hostPort, ContainerCreation container) {
-		this.hostPort = hostPort;
-		this.container = container;
+	public void start() {
+		s3.start();
 	}
 
-	public static FakeS3 create(DockerClient dockerClient) throws DockerException, InterruptedException, IOException {
-		// make sure we have the image
-		dockerClient.pull(IMAGE, System.err::println);
-
-		Path directory = Files.createTempDirectory("fakeS3");
-
-		// bind a fakes3 image to a random host port
-		int port = InstanceSpec.getRandomPort();
-		return new FakeS3(port, dockerClient.createContainer(ContainerConfig.builder()
-			.hostConfig(HostConfig.builder().portBindings(ImmutableMap.of(
-				CONTAINER_PORT, ImmutableList.of(PortBinding.of("0.0.0.0", port))
-			)).build())
-			.image(IMAGE)
-			.exposedPorts(ImmutableSet.of(CONTAINER_PORT))
-			.build()));
-	}
-
-	public void start(DockerClient dockerClient) throws DockerException, InterruptedException, IOException {
-		dockerClient.startContainer(container.id());
-		Thread thread = new Thread(() -> {
-			try {
-				dockerClient.attachContainer(container.id(),
-					DockerClient.AttachParameter.LOGS,
-					DockerClient.AttachParameter.STDOUT,
-					DockerClient.AttachParameter.STDERR,
-					DockerClient.AttachParameter.STREAM)
-					.attach(System.out, System.err);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		});
-		thread.setDaemon(true);
-		thread.start();
-	}
-
-	public void close(DockerClient dockerClient) throws DockerException, InterruptedException {
-		dockerClient.stopContainer(container.id(), 10);
-		dockerClient.removeContainer(container.id());
+	public void close() {
+		s3.close();
 	}
 
 	public String getEndpoint() {
-		return "http://localhost:" + hostPort;
+		return String.format("http://%s:%s", s3.getHost(), s3.getFirstMappedPort());
 	}
 }

--- a/system_test/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
+++ b/system_test/src/test/java/com/spredfast/kafka/connect/s3/FakeS3.java
@@ -12,8 +12,9 @@ import org.testcontainers.utility.DockerImageName;
 public class FakeS3 {
 
 	@Container
-	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("lphoward/fake-s3"))
-		.withExposedPorts(4569);
+	public GenericContainer s3 = new GenericContainer(DockerImageName.parse("adobe/s3mock"))
+		.withExposedPorts(9090);
+
 
 	public void start() {
 		s3.start();

--- a/system_test/src/test/java/com/spredfast/kafka/test/KafkaIntegrationTests.java
+++ b/system_test/src/test/java/com/spredfast/kafka/test/KafkaIntegrationTests.java
@@ -1,45 +1,49 @@
 package com.spredfast.kafka.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.function.Consumer;
-import java.util.function.IntConsumer;
-import java.util.function.Supplier;
-
-import org.apache.kafka.common.utils.SystemTime;
-import org.apache.kafka.connect.runtime.Connect;
-import org.apache.kafka.connect.runtime.ConnectorFactory;
-import org.apache.kafka.connect.runtime.Herder;
-import org.apache.kafka.connect.runtime.Worker;
-import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.runtime.rest.RestServer;
-import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
-import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
-import org.apache.kafka.connect.storage.FileOffsetBackingStore;
 import com.google.common.base.Functions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.netflix.curator.test.InstanceSpec;
 import com.netflix.curator.test.TestingServer;
-
-import kafka.admin.AdminUtils;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
-import kafka.utils.SystemTime$;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.Worker;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
+import org.apache.kafka.connect.storage.FileOffsetBackingStore;
+import org.apache.kafka.connect.util.ConnectUtils;
+import org.apache.kafka.metadata.BrokerState;
 import scala.Option;
-import scala.collection.JavaConversions;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class KafkaIntegrationTests {
 
@@ -47,18 +51,6 @@ public class KafkaIntegrationTests {
 
 	public static Kafka givenLocalKafka() throws Exception {
 		return new Kafka();
-	}
-
-	public static void givenLocalKafka(int kafkaPort, IntConsumer localPort) throws Exception {
-		try (Kafka kafka = givenLocalKafka()) {
-			localPort.accept(kafka.localPort());
-		}
-	}
-
-	public static void givenKafkaConnect(int kafkaPort, Consumer<Herder> consumer) throws Exception {
-		try (KafkaConnect connect = givenKafkaConnect(kafkaPort)) {
-			consumer.accept(connect.herder());
-		}
 	}
 
 	public static void waitForPassing(Duration timeout, Runnable test) {
@@ -109,7 +101,7 @@ public class KafkaIntegrationTests {
 			.put("offset.storage.file.filename", tempFile.getCanonicalPath())
 			.put("offset.flush.interval.ms", "1000")
 			.put("consumer.metadata.max.age.ms", "1000")
-			.put("rest.port", "" + InstanceSpec.getRandomPort())
+			.put("listeners", "http://localhost:" + InstanceSpec.getRandomPort())
 			.build()
 		);
 		props.putAll(overrides);
@@ -117,11 +109,30 @@ public class KafkaIntegrationTests {
 		return givenKafkaConnect(props);
 	}
 
+	public static AdminClient givenAnAdminClient(int kafkaPort) {
+		return AdminClient.create(
+			new HashMap<>(ImmutableMap.<String, String>builder()
+				.put("bootstrap.servers", "localhost:" + kafkaPort)
+				.build())
+		);
+	}
+
 	private static KafkaConnect givenKafkaConnect(Map<String, String> props) {
 		WorkerConfig config = new StandaloneConfig(props);
-		Worker worker = new Worker("1", new SystemTime(), new ConnectorFactory(), config, new FileOffsetBackingStore());
-		Herder herder = new StandaloneHerder(worker);
+		Plugins plugins = new Plugins(props);
+		plugins.compareAndSwapWithDelegatingLoader();
+		ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy = plugins.newPlugin(
+			config.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
+			config, ConnectorClientConfigOverridePolicy.class);
+
+		String workerId = props.get("bootstrap.servers");
+		Worker worker = new Worker(workerId, new SystemTime(), plugins, config, new FileOffsetBackingStore(),
+			connectorClientConfigOverridePolicy);
+		Herder herder = new StandaloneHerder(worker, ConnectUtils.lookupKafkaClusterId(config), connectorClientConfigOverridePolicy);
+
+
 		RestServer restServer = new RestServer(config);
+		restServer.initializeServer();
 		Connect connect = new Connect(herder, restServer);
 		connect.start();
 		return new KafkaConnect(connect, herder, () -> givenKafkaConnect(props));
@@ -158,22 +169,27 @@ public class KafkaIntegrationTests {
 		private final TestingServer zk;
 		private final KafkaServer kafkaServer;
 
+		private final int localPort;
+
 		public Kafka() throws Exception {
 			zk = new TestingServer();
+			localPort = InstanceSpec.getRandomPort();
 			File tmpDir = Files.createTempDir();
 			KafkaConfig config = new KafkaConfig(Maps.transformValues(ImmutableMap.<String, Object>builder()
-				.put("port", InstanceSpec.getRandomPort())
+				.put("listeners", "PLAINTEXT://localhost:" + localPort)
+				.put("advertised.listeners", "PLAINTEXT://localhost:" + localPort)
+				.put("port", localPort)
 				.put("broker.id", "1")
 				.put("offsets.topic.replication.factor", 1)
 				.put("log.dir", tmpDir.getCanonicalPath())
 				.put("zookeeper.connect", zk.getConnectString())
 				.build(), Functions.toStringFunction()));
-			kafkaServer = new KafkaServer(config, SystemTime$.MODULE$, Option.empty(), JavaConversions.asScalaBuffer(ImmutableList.of()));
+			kafkaServer = new KafkaServer(config, Time.SYSTEM, Option.empty(), true);
 			kafkaServer.startup();
 		}
 
-		public int localPort() {
-			return kafkaServer.config().advertisedPort();
+		public int getLocalPort() {
+			return localPort;
 		}
 
 		@Override
@@ -188,31 +204,44 @@ public class KafkaIntegrationTests {
 		}
 
 		public String createUniqueTopic(String prefix, int partitions) throws InterruptedException {
-			return createUniqueTopic(prefix, partitions, new Properties());
+			return createUniqueTopic(prefix, partitions, new HashMap<>());
 		}
 
-		public String createUniqueTopic(String prefix, int partitions, Properties topicConfig) throws InterruptedException {
+		public String createUniqueTopic(String prefix, int partitions, Map<String, String> topicConfig) {
 			checkReady();
+
 			String topic = (prefix + UUID.randomUUID().toString().substring(0, 5)).replaceAll("[^a-zA-Z0-9._-]", "_");
-			AdminUtils.createTopic(kafkaServer.zkUtils(), topic, partitions, 1, topicConfig, AdminUtils.createTopic$default$6());
-			waitForPassing(Duration.ofSeconds(5), () -> {
-				assertTrue(AdminUtils.fetchTopicMetadataFromZk(topic, kafkaServer.zkUtils())
-					.partitionMetadata().stream()
-					.allMatch(pm -> !pm.leader().isEmpty()));
-			});
+			short replicationFactor = 1;
+			List<NewTopic> topics = new ArrayList<>();
+			topics.add(new NewTopic(topic, partitions, replicationFactor));
+
+			try (AdminClient admin = givenAnAdminClient(localPort)) {
+				admin.createTopics(topics);
+			}
+			updateTopic(topic, topicConfig);
+
 			return topic;
 		}
 
-		public void updateTopic(String topic, Properties topicConfig) {
-			AdminUtils.changeTopicConfig(kafkaServer.zkUtils(), topic, topicConfig);
+		public void updateTopic(String topic, Map<String, String> topicConfig) {
+			List<AlterConfigOp> topicAlterations = topicConfig.entrySet().stream()
+				.map((entry) -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
+				.collect(Collectors.toList());
+
+			Map<ConfigResource, Collection<AlterConfigOp>> alterations = new HashMap<>();
+			alterations.put(new ConfigResource(ConfigResource.Type.TOPIC, topic), topicAlterations);
+
+			try (AdminClient admin = givenAnAdminClient(localPort)) {
+				admin.incrementalAlterConfigs(alterations);
+			}
 		}
 
-		public void checkReady() throws InterruptedException {
+		public void checkReady() {
 			checkReady(Duration.ofSeconds(15));
 		}
 
-		public void checkReady(Duration timeout) throws InterruptedException {
-			waitForPassing(timeout, () -> assertNotNull(kafkaServer.kafkaHealthcheck()));
+		public void checkReady(Duration timeout) {
+			waitForPassing(timeout, () -> assertEquals(BrokerState.RUNNING, kafkaServer.brokerState()));
 		}
 	}
 


### PR DESCRIPTION
Fixes a bunch of broken tests by updating dependencies and Docker images.

Updates `ByteLengthFormat` and `BytesRecordReader` to serialise and deserialise headers, respectively.

Also updates `TrailingDelimiterFormat` and `DelimitedRecordReader` to handle headers in a similar way -- although we do not use these outside of tests, it's nice to have parity.